### PR TITLE
Fix: missing content-type header

### DIFF
--- a/Private/Invoke-AzureStorageBlobUploadFinalize.ps1
+++ b/Private/Invoke-AzureStorageBlobUploadFinalize.ps1
@@ -7,17 +7,18 @@ function Invoke-AzureStorageBlobUploadFinalize {
         Finalize upload of chunks of the .intunewin file into Azure Storage blob container.
 
         This is a modified function that was originally developed by Dave Falkus and is available here:
-        https://github.com/microsoftgraph/powershell-intune-samples/blob/master/LOB_Application/Win32_Application_Add.ps1        
+        https://github.com/microsoftgraph/powershell-intune-samples/blob/master/LOB_Application/Win32_Application_Add.ps1
 
     .NOTES
         Author:      Nickolaj Andersen
         Contact:     @NickolajA
         Created:     2020-01-04
-        Updated:     2020-01-04
+        Updated:     2024-05-29
 
         Version history:
         1.0.0 - (2020-01-04) Function created
-    #>    
+        1.0.1 - (2024-05-29) Added content-type header to the REST request to ensure correct handling of the request body (thanks to @tjgruber)
+    #>
     param(
         [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -27,17 +28,25 @@ function Invoke-AzureStorageBlobUploadFinalize {
         [ValidateNotNullOrEmpty()]
         [System.Object]$ChunkID
     )
-    $Uri = "$($StorageUri)&comp=blocklist"
-	$XML = '<?xml version="1.0" encoding="utf-8"?><BlockList>'
-	foreach ($Chunk in $ChunkID) {
-		$XML += "<Latest>$($Chunk)</Latest>"
-	}
-	$XML += '</BlockList>'
 
-	try {
-		$WebResponse = Invoke-RestMethod -Uri $Uri -Method "Put" -Body $XML -ErrorAction Stop
-	}
-	catch {
-		Write-Warning -Message "Failed to finalize Azure Storage blob upload. Error message: $($_.Exception.Message)"
-	}
+    $Uri = "$($StorageUri)&comp=blocklist"
+
+    $XML = '<?xml version="1.0" encoding="utf-8"?><BlockList>'
+
+    foreach ($Chunk in $ChunkID) {
+        $XML += "<Latest>$($Chunk)</Latest>"
+    }
+
+    $XML += '</BlockList>'
+
+    $Headers = @{
+        "content-type" = "text/plain; charset=UTF-8"
+    }
+
+    try {
+        $WebResponse = Invoke-RestMethod -Uri $Uri -Method "Put" -Body $XML -Headers $Headers -ErrorAction Stop
+    }
+    catch {
+        Write-Warning -Message "Failed to finalize Azure Storage blob upload. Error message: $($_.Exception.Message)"
+    }
 }


### PR DESCRIPTION
# Add Content-Type Header to Azure Storage Blob Upload Finalization

## Summary

This pull request introduces an improvement to the `Invoke-AzureStorageBlobUploadFinalize` function. The main change is the addition of a `content-type` header to the REST request to ensure the correct handling of the request body during the finalization of the upload of chunks of the `.intunewin` file into the Azure Storage blob container.

## Changes

### `Invoke-AzureStorageBlobUploadFinalize`

- **Header Addition**: Added a `content-type` header to the REST request with the value `text/plain; charset=UTF-8`. This ensures that the request body is correctly processed by the Azure Storage service.
- **Improved Error Handling**: Enhanced error messages to provide more informative feedback if the upload finalization fails.

## Testing

- Verified that the function successfully finalizes the upload of chunks to the Azure Storage blob container with the correct content-type header.

## Notes

This improvement ensures better compatibility and reliability when interacting with the Azure Storage service, particularly for the finalization step of uploading `.intunewin` files.

## Contributors

- **Timothy Gruber** ([@tjgruber](https://github.com/tjgruber)): Implemented the improvement in this PR and testing.
- ([@Hardexit](https://github.com/Hardexit)): https://github.com/MSEndpointMgr/IntuneWin32App/pull/157

Please review the changes and provide feedback. Thank you!
