### PR TITLE
13: Fix: Resolve File Access Conflicts by Making Expand Folder Unique

### DIFF
--- a/Public/Add-IntuneWin32App.ps1
+++ b/Public/Add-IntuneWin32App.ps1
@@ -114,6 +114,7 @@ function Add-IntuneWin32App {
                              Added CategoryName parameter. UseAzCopy parameter will now only be allowed if content size is 100MB or more.
         1.1.0 - (2023-03-17) Added parameter switch AllowAvailableUninstall. Fixed issue #77 related to scope tags and custom roles.
         1.1.1 - (2023-09-02) Added parameter MaximumInstallationTimeInMinutes. Updated with Test-AccessToken function.
+        1.1.2 - (2024-12-19) Added logic to make Expand folder unique to avoid file access conflicts. (tjgruber)
     #>
     [CmdletBinding(SupportsShouldProcess=$true, DefaultParameterSetName = "MSI")]
     param(
@@ -575,7 +576,8 @@ function Add-IntuneWin32App {
                     }
                     else {
                         # Extract compressed .intunewin file to subfolder
-                        $IntuneWinFilePath = Expand-IntuneWin32AppCompressedFile -FilePath $FilePath -FileName $IntuneWinXMLMetaData.ApplicationInfo.FileName -FolderName "Expand"
+                        $SubFolderName = "Expand_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 12)
+                        $IntuneWinFilePath = Expand-IntuneWin32AppCompressedFile -FilePath $FilePath -FileName $IntuneWinXMLMetaData.ApplicationInfo.FileName -FolderName $SubFolderName
                         if ($IntuneWinFilePath -ne $null) {
                             # Create a new file entry in Intune for the upload of the .intunewin file
                             Write-Verbose -Message "Constructing Win32 app content file body for uploading of .intunewin file"

--- a/Public/Update-IntuneWin32AppPackageFile.ps1
+++ b/Public/Update-IntuneWin32AppPackageFile.ps1
@@ -25,6 +25,7 @@ function Update-IntuneWin32AppPackageFile {
         1.0.3 - (2021-08-31) Fixed an issue where the PATCH operation would remove the largeIcon property value of the Win32 app
         1.0.4 - (2023-01-20) Updated regex pattern for parameter FilePath
         1.0.5 - (2023-09-04) Updated with Test-AccessToken function
+        1.0.6 - (2024-12-19) Added logic to make Expand folder unique to avoid file access conflicts. (tjgruber)
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
@@ -92,7 +93,8 @@ function Update-IntuneWin32AppPackageFile {
                     Write-Verbose -Message "Successfully created contentVersions resource with ID: $($Win32AppContentVersionRequest.id)"
 
                     # Extract compressed .intunewin file to subfolder
-                    $IntuneWinFilePath = Expand-IntuneWin32AppCompressedFile -FilePath $FilePath -FileName $IntuneWinXMLMetaData.ApplicationInfo.FileName -FolderName "Expand"
+                    $SubFolderName = "Expand_" + [System.Guid]::NewGuid().ToString("N").Substring(0, 12)
+                    $IntuneWinFilePath = Expand-IntuneWin32AppCompressedFile -FilePath $FilePath -FileName $IntuneWinXMLMetaData.ApplicationInfo.FileName -FolderName $SubFolderName
                     if ($IntuneWinFilePath -ne $null) {
                         # Create a new file entry in Intune for the upload of the .intunewin file
                         Write-Verbose -Message "Constructing Win32 app content file body for uploading of .intunewin file"


### PR DESCRIPTION
**Description:**  
This update introduces logic to ensure the `Expand` folder used during the extraction of `.intunewin` files is unique for each operation. By appending a unique GUID-based identifier to the folder name, this change prevents potential file access conflicts during simultaneous operations. 

**Key Changes:**  
- Updated `Add-IntuneWin32App` to generate a unique folder name (`Expand_<GUID>`).
- Updated `Update-IntuneWin32AppPackageFile` with the same logic for consistency.
- Modified related logic to handle the unique folder naming structure.
- Added changelog entries:
  - `Add-IntuneWin32App` to version `1.1.2`
  - `Update-IntuneWin32AppPackageFile` to version `1.0.6`

**Testing:**  
Tested locally and in GitHub Actions Windows/Linux to ensure the following:  
1. Unique folder names are generated for each operation.
2. Folder conflicts are avoided during parallel or consecutive operations.
3. No regressions in existing functionality.
