### PR TITLE
Add Retry Logic for Transient Graph API Errors in Invoke-IntuneGraphRequest

### DIFF
--- a/Private/Invoke-IntuneGraphRequest.ps1
+++ b/Private/Invoke-IntuneGraphRequest.ps1
@@ -19,7 +19,7 @@ function Invoke-IntuneGraphRequest {
         1.0.3 - (2022-10-02) Changed content type for requests to support UTF8
         1.0.4 - (2023-01-23) Added non-mandatory Route parameter to support different routes of Graph API in addition to better handle error response body depending on PSEdition
         1.0.5 - (2023-02-03) Improved error handling
-        1.0.6 - (2024-12-24) Added retry logic to handle transient errors like 429 TooManyRequests. (tjgruber)
+        1.0.6 - (2024-12-24) Added retry logic to handle transient errors and improved error handling for pipeline use. (tjgruber)
     #>
     param(
         [parameter(Mandatory = $true)]


### PR DESCRIPTION
Enhanced the `Invoke-IntuneGraphRequest` function to handle transient Graph API errors more robustly. Added retry logic for scenarios such as `429 TooManyRequests`, `Timeout`, and `ServiceUnavailable` responses, with improved warnings and error handling. This is valuable when running in automated pipelines.