### PR TITLE
Add 429 and 503 transient error matches

### DIFF
--- a/Private/Invoke-IntuneGraphRequest.ps1
+++ b/Private/Invoke-IntuneGraphRequest.ps1
@@ -70,7 +70,7 @@ function Invoke-IntuneGraphRequest {
     # Retry parameters
     $RetryCount = 5
     $RetryDelayRange = @{ Min = 7; Max = 13 }
-    $TransientErrors = "TransientError|Timeout|ServiceUnavailable|TooManyRequests"
+    $TransientErrors = "TransientError|Timeout|ServiceUnavailable|TooManyRequests|429|503"
 
     for ($Attempt = 1; $Attempt -le $RetryCount; $Attempt++) {
         try {


### PR DESCRIPTION
This PR adds 429 and 503 to the transient error message matches.