### PR TITLE
- Fix `DateTimeOffset` parsing and `Win32AppAssignmentResponse` empty return issues

### DIFF
--- a/Private/Invoke-AzureStorageBlobUpload.ps1
+++ b/Private/Invoke-AzureStorageBlobUpload.ps1
@@ -13,15 +13,16 @@ function Invoke-AzureStorageBlobUpload {
         Author:      Nickolaj Andersen
         Contact:     @NickolajA
         Created:     2020-01-04
-        Updated:     2024-11-15
+        Updated:     2026-02-04
 
         Version history:
         1.0.0 - (2020-01-04) Function created
         1.0.1 - (2020-09-20) Fixed an issue where the System.IO.BinaryReader wouldn't open a file path containing whitespaces
         1.0.2 - (2021-03-15) Fixed an issue where SAS Uri renewal wasn't working correctly
         1.0.3 - (2022-09-03) Added access token refresh functionality when a token is about to expire, to prevent uploads from failing due to an expired access token
-        1.0.5 - (2024-06-04) Added retry logic for chunk uploads and finalization steps to enhance reliability (thanks to @tjgruber)
-        1.0.6 - (2024-11-15) Refactor date handling for token to fix locale-specific parsing issues (thanks to @tjgruber)
+        1.0.5 - (2024-06-04) Added retry logic for chunk uploads and finalization steps to enhance reliability (@tjgruber)
+        1.0.6 - (2024-11-15) Refactor date handling for token to fix locale-specific parsing issues (@tjgruber)
+        1.0.7 - (2026-02-04) Fixed invariant culture parsing issue in DateTimeOffset conversion (@tjgruber)
     #>
     param(
         [parameter(Mandatory = $true)]
@@ -58,7 +59,7 @@ function Invoke-AzureStorageBlobUpload {
 
         # Convert ExpiresOn to DateTimeOffset in UTC
         $ExpiresOnUTC = [DateTimeOffset]::Parse(
-            $Global:AccessToken.ExpiresOn.ToString(),
+            $Global:AccessToken.ExpiresOn.ToString([System.Globalization.CultureInfo]::InvariantCulture),
             [System.Globalization.CultureInfo]::InvariantCulture,
             [System.Globalization.DateTimeStyles]::AssumeUniversal
             ).ToUniversalTime()

--- a/Public/Remove-IntuneWin32AppAssignment.ps1
+++ b/Public/Remove-IntuneWin32AppAssignment.ps1
@@ -32,7 +32,7 @@ function Remove-IntuneWin32AppAssignment {
 
         [parameter(Mandatory = $true, ParameterSetName = "ID", HelpMessage = "Specify the ID for a Win32 application.")]
         [ValidateNotNullOrEmpty()]
-        [string]$ID      
+        [string]$ID
     )
     Begin {
         # Ensure required authentication header variable exists
@@ -76,13 +76,14 @@ function Remove-IntuneWin32AppAssignment {
             try {
                 # Attempt to call Graph and retrieve all assignments for Win32 app
                 $Win32AppAssignmentResponse = Invoke-MSGraphOperation -Get -APIVersion "Beta" -Resource "deviceAppManagement/mobileApps/$($Win32AppID)/assignments" -ErrorAction Stop
-                if ($null -ne $Win32AppAssignmentResponse -and $Win32AppAssignmentResponse.Count -gt 0) {
-                    Write-Verbose -Message "Count of assignments for Win32 app before attempted removal process: $(($Win32AppAssignmentResponse | Measure-Object).Count)"
+                $Win32AppAssignments = @($Win32AppAssignmentResponse.value)
+                if ($null -ne $Win32AppAssignmentResponse -and $Win32AppAssignments.Count -gt 0) {
+                    Write-Verbose -Message "Count of assignments for Win32 app before attempted removal process: $(($Win32AppAssignments | Measure-Object).Count)"
 
                     # Process each assignment for removal
-                    foreach ($Win32AppAssignment in $Win32AppAssignmentResponse) {
+                    foreach ($Win32AppAssignment in $Win32AppAssignments) {
                         Write-Verbose -Message "Attempting to remove Win32 app assignment with ID: $($Win32AppAssignment.id)"
-                        
+
                         try {
                             # Remove current assignment
                             $Win32AppAssignmentRemoveResponse = Invoke-MSGraphOperation -Delete -APIVersion "Beta" -Resource "deviceAppManagement/mobileApps/$($Win32AppID)/assignments/$($Win32AppAssignment.id)" -ErrorAction Stop
@@ -94,7 +95,8 @@ function Remove-IntuneWin32AppAssignment {
 
                     # Calculate amount of remaining assignments after attempted removal process
                     $Win32AppAssignmentResponse = Invoke-MSGraphOperation -Get -APIVersion "Beta" -Resource "deviceAppManagement/mobileApps/$($Win32AppID)/assignments" -ErrorAction Stop
-                    Write-Verbose -Message "Count of assignments for Win32 app after attempted removal process: $(($Win32AppAssignmentResponse | Measure-Object).Count)"
+                    $Win32AppAssignments = @($Win32AppAssignmentResponse.value)
+                    Write-Verbose -Message "Count of assignments for Win32 app after attempted removal process: $(($Win32AppAssignments | Measure-Object).Count)"
                 }
                 else {
                     Write-Verbose -Message "Unable to locate any instances for removal, Win32 app does not have any existing assignments"

--- a/Public/Remove-IntuneWin32AppAssignment.ps1
+++ b/Public/Remove-IntuneWin32AppAssignment.ps1
@@ -16,13 +16,14 @@ function Remove-IntuneWin32AppAssignment {
         Author:      Nickolaj Andersen
         Contact:     @NickolajA
         Created:     2020-04-29
-        Updated:     2023-09-04
+        Updated:     2026-02-04
 
         Version history:
         1.0.0 - (2020-04-29) Function created
         1.0.1 - (2021-04-01) Updated token expired message to a warning instead of verbose output
         1.0.2 - (2021-08-31) Updated to use new authentication header
         1.0.3 - (2023-09-04) Updated with Test-AccessToken function
+        1.0.4 - (2026-02-04) Fixed issue causing incorrect behavior when empty assignments list is returned (@tjgruber)
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(

--- a/Public/Test-AccessToken.ps1
+++ b/Public/Test-AccessToken.ps1
@@ -13,7 +13,7 @@ function Test-AccessToken {
         Author:      Nickolaj Andersen
         Contact:     @NickolajA
         Created:     2021-04-08
-        Updated:     2024-11-15
+        Updated:     2026-02-04
 
         Version history:
         1.0.0 - (2021-04-08) Script created
@@ -22,6 +22,7 @@ function Test-AccessToken {
         1.0.3 - (2024-05-29) Updated to handle tokens with ExpiresOn property (thanks to @tjgruber)
         1.0.4 - (2024-11-15) Refactor date handling for token to fix locale-specific parsing issues (thanks to @tjgruber)
         1.0.5 - (2025-12-07) Reduced default RenewalThresholdMinutes from 10 to 5 minutes to avoid conflicts with minimum Access Token Lifetime policies
+        1.0.6 - (2026-02-04) Fixed invariant culture parsing issue in DateTimeOffset conversion (@tjgruber)
     #>
     param(
         [parameter(Mandatory = $false, HelpMessage = "Specify the renewal threshold for access token age in minutes.")]
@@ -46,7 +47,7 @@ function Test-AccessToken {
             }
 
             # Convert ExpiresOn to DateTimeOffset in UTC
-            $ExpiresOnUTC = [DateTimeOffset]::Parse($Global:AccessToken.ExpiresOn.ToString(), [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal).ToUniversalTime()
+            $ExpiresOnUTC = [DateTimeOffset]::Parse($Global:AccessToken.ExpiresOn.ToString([System.Globalization.CultureInfo]::InvariantCulture), [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal).ToUniversalTime()
 
             # Get the current UTC time as DateTimeOffset
             $UTCDateTime = [DateTimeOffset]::UtcNow


### PR DESCRIPTION
- Fix Win32AppAssignmentResponse parsing issue in `Remove-IntuneWin32AppAssignment.ps1`.
  When an empty assignments list is returned from the API, the script now correctly handles it.
  Prior to this fix, an empty assignments list could count as `1` assignment, leading to incorrect behavior.
- Fixed invariant culture parsing issue in DateTimeOffset conversion.
  Implements this [PR](https://github.com/MSEndpointMgr/IntuneWin32App/pull/212) awaiting upstream implementation.